### PR TITLE
ADM-166; (Feat) Add string conversion to integers in Select component and some corrections to filters logic

### DIFF
--- a/admiral/filters/AppliedFilters.tsx
+++ b/admiral/filters/AppliedFilters.tsx
@@ -44,7 +44,7 @@ export const AppliedFilters: React.FC<AppliedFiltersProps> = () => {
 
                     if (isMultiple) {
                         const labels = options
-                            ? value.map((i) => options.find((o) => o.value === i)?.label ?? i)
+                            ? value.map((i) => options.find((o) => o.value == i)?.label ?? i)
                             : [value.length]
 
                         const optionName = labels.length > 1 ? labels.length : labels[0]
@@ -52,7 +52,7 @@ export const AppliedFilters: React.FC<AppliedFiltersProps> = () => {
                     }
 
                     const optionName = options
-                        ? options.find((n) => n.value === value)?.label ?? value
+                        ? options.find((n) => n.value == value)?.label ?? value
                         : value
                     return label ? `${label}: ${optionName}` : optionName
                 }

--- a/admiral/filters/QuickFilters.tsx
+++ b/admiral/filters/QuickFilters.tsx
@@ -25,7 +25,6 @@ export const QuickFilters: React.FC<QuickFiltersProps> = ({ filters }) => {
     } = useCrudIndex()
     const { values, setValues, setOptions } = useForm()
     const { filter } = urlState
-
     const shouldUpdateUrlState = useRef(true)
 
     useLayoutEffect(() => {
@@ -64,6 +63,7 @@ export const QuickFilters: React.FC<QuickFiltersProps> = ({ filters }) => {
                 locale: props?.locale,
                 style: props?.style,
                 children: props?.children,
+                suffix: props?.suffix,
             }
 
             switch (type) {

--- a/admiral/ui/Select/Select.tsx
+++ b/admiral/ui/Select/Select.tsx
@@ -70,6 +70,11 @@ const InternalSelect = <OptionType extends BaseOptionType | DefaultOptionType = 
         className,
     )
 
+    const getValue = (value?: OptionType | null) =>
+        value ? (Number.isInteger(+value) ? +value : value) : undefined
+    const value = selectProps.value
+    const selectValue = value ? (isMultiple ? value.map(getValue) : getValue(value)) : undefined
+
     return (
         <RcSelect<any, any>
             ref={ref as any}
@@ -78,6 +83,7 @@ const InternalSelect = <OptionType extends BaseOptionType | DefaultOptionType = 
             dropdownMatchSelectWidth={dropdownMatchSelectWidth}
             maxTagCount={maxTagCount}
             {...selectProps}
+            value={selectValue}
             className={mergedClassName}
             animation="slide-up"
             listHeight={listHeight}


### PR DESCRIPTION
When we get the values from the url query, they come as a string. However, numeric values are set in options for Select on the server. Under the hood of rc-select, these values are compared without type conversion and an error is obtained, which is why we need to convert strings to numbers in Select component.

In the AppliedFilters component, I removed the strict equality to solve the same problem.

I also allowed passing a suffix prop at QuickFilters component.