### PR TITLE
Menu footer width bug

### DIFF
--- a/admiral/ui/Layout/Layout.module.scss
+++ b/admiral/ui/Layout/Layout.module.scss
@@ -248,6 +248,10 @@
             width: 100%;
         }
     }
+
+    .userCard {
+        width: 100%;
+    }
 }
 
 .settings {

--- a/admiral/ui/Layout/Layout.module.scss
+++ b/admiral/ui/Layout/Layout.module.scss
@@ -239,7 +239,6 @@
 .user {
     display: flex;
     align-items: center;
-    justify-content: flex-end;
 
     &__Collapsed {
         justify-content: center;

--- a/admiral/ui/Layout/LayoutFooter/index.tsx
+++ b/admiral/ui/Layout/LayoutFooter/index.tsx
@@ -53,7 +53,7 @@ const LayoutFooter: React.FC<Props> = ({ user, menuPopupExtraComponents }) => {
                     }}
                 >
                     {user ? (
-                        <div>
+                        <div className={styles.userCard}>
                             <UserCard {...user} collapsed={collapsed} />
                         </div>
                     ) : (


### PR DESCRIPTION
the width of the card is determined by the content and the card itself uses `justify-content: flex-end;` for the positioning of the tooltip (as far as I understood) => the card is align to right

I'm replaced `justify-content: flex-end;` with `width: 100%` in the parent `div` to achieve the same result, but with left alignment

*Before:*
![image](https://github.com/user-attachments/assets/04a29c87-4a9b-4f11-ab3a-1202ac94214a)

*After:*
![image](https://github.com/user-attachments/assets/50b66863-a7b7-4c7e-8243-d387af832385)
